### PR TITLE
improve automated graphql instrumentation

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -30,7 +30,14 @@ func (t Tracer) Validate(graphql.ExecutableSchema) error {
 	return nil
 }
 
+// InterceptField instruments timing of individual fields resolved.
 func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+	// if we don't have a highlight session in the context, no point trying to
+	// instrument since we won't be able to store the metric
+	if _, _, err := validateRequest(ctx); err != nil {
+		return next(ctx)
+	}
+
 	fc := graphql.GetFieldContext(ctx)
 	name := fmt.Sprintf("operation.field.%s", fc.Field.Name)
 
@@ -38,11 +45,19 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	res, err := next(ctx)
 	end := graphql.Now()
 
-	RecordMetric(ctx, name+".duration", float64(end.Sub(start)))
+	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
 	return res, err
 }
 
+// InterceptResponse instruments timing, payload size, and error information
+// of the response handler. The metric is grouped by the corresponding operation name.
 func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	// if we don't have a highlight session in the context, no point trying to
+	// instrument since we won't be able to store the metric
+	if _, _, err := validateRequest(ctx); err != nil {
+		return next(ctx)
+	}
+
 	rc := graphql.GetOperationContext(ctx)
 	opName := "undefined"
 	if rc != nil && rc.Operation != nil {
@@ -55,7 +70,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	resp := next(ctx)
 	end := graphql.Now()
 
-	RecordMetric(ctx, name+".duration", float64(end.Sub(start)))
+	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
 	if resp.Errors != nil {
 		RecordMetric(ctx, name+".errorsCount", float64(len(resp.Errors)))
 	}


### PR DESCRIPTION
* avoid instrumenting requests that are missing the frontend tracing headers.
* ensure the highlight-go errors/metrics buffers do not block data submission and graphql request processing.