### PR TITLE
upgrade go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight-run/highlight-go
 
-go 1.17
+go 1.19
 
 require (
 	github.com/99designs/gqlgen v0.17.12


### PR DESCRIPTION
This PR upgrades to the latest version of go:

* [1.18 release notes](https://go.dev/doc/go1.18)
* [1.19 release notes](https://go.dev/doc/go1.19)